### PR TITLE
New options translated.

### DIFF
--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -60,4 +60,7 @@
     "m59": { "message" : "Ajude a traduzir o \"Twitch Now\"."},
     "m60": { "message" : "Se você quer ajudar a traduzir, visite \"Twitch Now\" no repositório do GitHub."},
     "m61": { "message" : "Selecione o idioma para abrir as páginas do Twitch.tv:"}
+    "m62": { "message" : "Largura da janela" },
+    "m63": { "message" : "não especificar idioma (Inglês)" },
+    "m64": { "message" : "Contribuintes:" }
 }


### PR DESCRIPTION
I'd like to point out that the extension is not updating automatically on Chrome. I had to remove it and install it again to get the updated translations and options.

There is no "Contributors" message to translate. That said, I added the line:
"m64": { "message" : "Contribuintes:" }
translated to english it means "Contributors".

Also, the Github icon message, under the Help & Info tab, is not being translated as it should be by using the line:
"m58": { "message" : "Repositório do GitHub!"}
