### PR TITLE
Added badge for Firefox 36 (currently in beta)

### DIFF
--- a/common/lib/utils.js
+++ b/common/lib/utils.js
@@ -63,7 +63,7 @@
       })
     }
     if ( browser == FIREFOX ) {
-//      throw new Error("Not Implemented");
+		self.port.emit("setbadge", opts.text);
     }
   }
 

--- a/common/lib/utils.js
+++ b/common/lib/utils.js
@@ -63,7 +63,7 @@
       })
     }
     if ( browser == FIREFOX ) {
-		self.port.emit("setbadge", opts.text);
+      self.port.emit("setbadge", opts.text);
     }
   }
 

--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -117,7 +117,11 @@ var button = buttons.ToggleButton({
     "16": self.data.url("common/icons/16_1.png"),
     "32": self.data.url("common/icons/32_1.png")
   },
-  onChange: onButtonStateChange
+  onChange: onButtonStateChange,
+  badge: "",
+});
+panel.port.on("setbadge", function(text) {
+	button.badge = text;
 });
 
 function onButtonStateChange(state){

--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -121,7 +121,7 @@ var button = buttons.ToggleButton({
   badge: "",
 });
 panel.port.on("setbadge", function(text) {
-	button.badge = text;
+  button.badge = text;
 });
 
 function onButtonStateChange(state){


### PR DESCRIPTION
Since firefox 36 supports badges on buttons, here is a patch that adds a badge with number of live streams. Will crash on firefox 35, so probably do not merge until that is actually out.

(I'm sorry if the code is slightly weird, first time writing firefox extension code. I just really wanted that badge for my own use.)