### PR TITLE
Fix h-num-format handlebars helper for 0 viewers

### DIFF
--- a/common/lib/handlebars-helpers.js
+++ b/common/lib/handlebars-helpers.js
@@ -26,7 +26,7 @@ Handlebars.registerHelper('h-checked-2', function (context, block){
 });
 
 Handlebars.registerHelper('h-num-format', function (v){
-  return v ? v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") : '';
+  return isNaN(v) ? '' : v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ");
 })
 
 Handlebars.registerHelper('h-uptime', function (v){


### PR DESCRIPTION
This returned an empty string for 0 viewers instead of 0.