### PR TITLE
Add support for Pale Moon 27.1+

### DIFF
--- a/firefox/package.json
+++ b/firefox/package.json
@@ -7,7 +7,8 @@
   "main": "lib/main.js",
   "author": "jdavid214@gmail.com",
   "engines": {
-    "firefox": ">=38.0a1"
+    "firefox": ">=38.0a1",
+    "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](http://developer.palemoon.org/Add-ons:Extensions/Jetpack), tested with [Pale Moon 27.1.0](http://www.palemoon.org/) and [Twitch Now 1.1.187](https://addons.mozilla.org/en-US/firefox/addon/twitch-now/versions/1.1.187).