### PR TITLE
add background color for online stream count text

### DIFF
--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -97,7 +97,7 @@
     "m96": { "message" : "全部取消桌面通知"},
     "m97": { "message" : "全部使用通知音效"},
     "m98": { "message" : "全部取消通知音效"},
-    "m99": { "message" : "重複撥放通知音效},
+    "m99": { "message" : "重複撥放通知音效"},
     "m100": { "message" : "在livestreamer中開啟"},
     "m101": { "message" : "html5 播放器 (不需要flash插件)"},
     "m102": { "message" : "只顯示選擇語言的串流:"},

--- a/common/lib/app.js
+++ b/common/lib/app.js
@@ -1503,6 +1503,8 @@
     },
     initialize       : function (){
       var self = this;
+      utils.browserAction.setBadgeBackgroundColor({"color": [100, 100, 100, 255]});
+
 
       self.on("change:count", function (){
         if ( settings.get("showBadge").get("value") ) {

--- a/common/lib/utils.js
+++ b/common/lib/utils.js
@@ -58,6 +58,10 @@
     })
   }
 
+  _browserAction.setBadgeBackgroundColor = function(color){
+    _browser.browserAction.setBadgeBackgroundColor(color);
+  }
+
   var _i18n = that.i18n = {};
 
   _i18n.getMessage = function (id){


### PR DESCRIPTION
I had an issue in Vivali browser (chromium based) with the background behind the online stream count being transparent and making the number unreadable.

Vivaldi:
![1500639712765-vivaldi](https://user-images.githubusercontent.com/11661539/28475013-0449993a-6e4b-11e7-8b57-e34681320307.png)

Chrome:
![1500639881934-chrome](https://user-images.githubusercontent.com/11661539/28475034-145978ea-6e4b-11e7-9650-c6f884f3f5d2.png)
