### PR TITLE
#238 Fix query with language attribute

### DIFF
--- a/common/lib/app.js
+++ b/common/lib/app.js
@@ -1266,7 +1266,7 @@
 
     defaultQuery: function () {
       return {
-        broadcaster_language: settings.get("streamLanguage").get("value"),
+        language: settings.get("streamLanguage").get("value"),
         limit: 50,
         offset: 0
       }


### PR DESCRIPTION
Fix for #238 
After the recent change for kraken API, twitch removed broadcaster_language attribute so I have changed it to language attribute.
But please note, that it will work only if the user selected only one language in settings, otherwise the list will be empty. I think we need to change language selector in setting from checkbox to radio button
link to post https://discuss.dev.twitch.tv/t/upcoming-changes-to-the-streams-v5-endpoints/23926/10 
